### PR TITLE
Fixes on the js part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ _build/
 # ocamlbuild targets
 *.byte
 *.native
+*.bc.js
+*.bc-for-jsoo
 
 # oasis generated files
 setup.data

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.24.1
+version = 0.25.1
 profile = janestreet
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nightmare
 
-> **Warning** *Nightmare* is still _Work In Progress_.
+> **Warning** _Nightmare_ is still _Work In Progress_.
 
 A set of components that fit, a priori, relatively well with the web framework
 ([OCaml](https://ocaml.org)) [Dream](https://aantron.github.io/dream/) to try to
@@ -25,7 +25,7 @@ initiate the environment:
 
 ```shellsession
 opam update
-opam switch create . ocaml-base-compiler.4.14.0 --deps-only -y
+opam switch create . ocaml-base-compiler.5.0.0 --deps-only -y
 eval $(opam env)
 ```
 
@@ -36,6 +36,7 @@ dependencies using `make`:
 make dev-deps
 make deps
 ```
+
 Now you should be able to easily start contributing to **Nightmare**.
 
 > **Note** If you are not using [GNU/Make](https://www.gnu.org/software/make/)

--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
  (synopsis "An ad-hoc framework for writing web application using OCaml")
  (description "An ad-hoc framework (that should fit well with Dream) for writting OCaml web application")
  (depends
-  (ocaml (>= 4.14.0))
+  (ocaml (>= 5.0.0))
   (dune (>= 3.0.0))
   (lwt (>= 5.6.1))
   (preface (>= 1.0.0))
@@ -30,7 +30,7 @@
  (synopsis "Glue between Nightmare and Dream")
  (description "An overlay built on top of Dream for using Nightmare tools")
  (depends
-  (ocaml (>= 4.14.0))
+  (ocaml (>= 5.0.0))
   (dune (>= 3.0.0))
   (dream (>= 1.0.0~alpha4))
   (nightmare (= :version))))
@@ -40,7 +40,7 @@
  (synopsis "Glue between Nightmare and TyXML")
  (description "Facilitates interaction between Nightmare and TyXML")
  (depends
-  (ocaml (>= 4.14.0))
+  (ocaml (>= 5.0.0))
   (dune (>= 3.0.0))
   (tyxml (>= 4.5.0))
   (nightmare (= :version))))
@@ -50,11 +50,11 @@
  (synopsis "The JavaScript Runtime for Nightmare JS Application")
  (description "A list of helpers to deal with Nightmare inside a Js_of_ocaml application")
  (depends
-  (ocaml (>= 4.14.0))
+  (ocaml (>= 5.0.0))
   (dune (>= 3.0.0))
   (lwt (>= 5.6.1))
   (preface (>= 1.0.0))
-  (js_of_ocaml-compiler (>= 5.0.1))
-  (js_of_ocaml-ppx (>= 5.0.1))
-  (js_of_ocaml-lwt (>= 5.0.1))
+  (js_of_ocaml-compiler (>= 5.2.0))
+  (js_of_ocaml-ppx (>= 5.2.0))
+  (js_of_ocaml-lwt (>= 5.2.0))
   (nightmare (= :version))))

--- a/examples/simple-js-interaction/bin/dune
+++ b/examples/simple-js-interaction/bin/dune
@@ -1,0 +1,7 @@
+(executable
+  (name index)
+  (modes js)
+  (preprocess (pps js_of_ocaml-ppx))
+  (js_of_ocaml (flags :standard))
+  (promote (until-clean) (into "../"))
+  (libraries nightmare_js))

--- a/examples/simple-js-interaction/bin/index.ml
+++ b/examples/simple-js-interaction/bin/index.ml
@@ -1,0 +1,3 @@
+open Nightmare_js
+
+let () = Console.(string log) "Hello, World"

--- a/examples/simple-js-interaction/index.html
+++ b/examples/simple-js-interaction/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Example</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+        <main id="app">
+            <h1>Hello, World</h1>
+            <span>A message should appear in the console.</span>
+        </main>
+        <script src="index.bc.js"></script>
+    </body>
+</html>

--- a/lib/js/bindings.mli
+++ b/lib/js/bindings.mli
@@ -41,6 +41,3 @@ class type console_hook =
     method timeLog : 'a. js_string t -> 'a -> unit meth
     method table : 'a. 'a -> js_string t js_array t or_undefined -> unit meth
   end
-
-(** Retreive the console implementation. *)
-external get_console : unit -> console_hook t = "caml_js_get_console"

--- a/lib/js/console.ml
+++ b/lib/js/console.ml
@@ -22,7 +22,12 @@
 
 open Js_of_ocaml
 
-let console = Bindings.get_console ()
+external get_console
+  :  unit
+  -> Bindings.console_hook Js.t
+  = "caml_js_get_console"
+
+let console = get_console ()
 let clear () = console##clear
 let log value = console##log value
 let debug value = console##debug value

--- a/nightmare.opam
+++ b/nightmare.opam
@@ -10,7 +10,7 @@ license: "MIT"
 homepage: "https://github.com/funkywork/nightmare"
 bug-reports: "https://github.com/funkywork/nightmare/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0" & >= "3.0.0"}
   "lwt" {>= "5.6.1"}
   "preface" {>= "1.0.0"}

--- a/nightmare_dream.opam
+++ b/nightmare_dream.opam
@@ -9,7 +9,7 @@ license: "MIT"
 homepage: "https://github.com/funkywork/nightmare"
 bug-reports: "https://github.com/funkywork/nightmare/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0" & >= "3.0.0"}
   "dream" {>= "1.0.0~alpha4"}
   "nightmare" {= version}

--- a/nightmare_js.opam
+++ b/nightmare_js.opam
@@ -10,13 +10,13 @@ license: "MIT"
 homepage: "https://github.com/funkywork/nightmare"
 bug-reports: "https://github.com/funkywork/nightmare/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0" & >= "3.0.0"}
   "lwt" {>= "5.6.1"}
   "preface" {>= "1.0.0"}
-  "js_of_ocaml-compiler" {>= "5.0.1"}
-  "js_of_ocaml-ppx" {>= "5.0.1"}
-  "js_of_ocaml-lwt" {>= "5.0.1"}
+  "js_of_ocaml-compiler" {>= "5.2.0"}
+  "js_of_ocaml-ppx" {>= "5.2.0"}
+  "js_of_ocaml-lwt" {>= "5.2.0"}
   "nightmare" {= version}
   "odoc" {with-doc}
 ]

--- a/nightmare_tyxml.opam
+++ b/nightmare_tyxml.opam
@@ -9,7 +9,7 @@ license: "MIT"
 homepage: "https://github.com/funkywork/nightmare"
 bug-reports: "https://github.com/funkywork/nightmare/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0" & >= "3.0.0"}
   "tyxml" {>= "4.5.0"}
   "nightmare" {= version}


### PR DESCRIPTION
- The first commit forces OCaml 5 as the minimum version (since Nightmare has no user, I think it's a good thing to force itself to use OCaml 5) and updates the version of OCamlformat.
- The second fixes a problem preventing the use of the Console module (so that Nightmare was not used for `ladmm-sa`.
- The third introduces an `examples` directory that we can populate as we go along. At first, it is mainly used to quickly test interactions with JavaScript.

