### PR TITLE
Add WebStorage in Nightmare_js

### DIFF
--- a/lib/js/interfaces.mli
+++ b/lib/js/interfaces.mli
@@ -247,11 +247,13 @@ module type STORAGE = sig
       [p key value]. *)
   val filter : (key -> value -> bool) -> slice
 
-  (* (\** {1 Event Handling} *\) *)
+  (** {1 Event Handling} *)
 
-  (* val on_change *)
-  (*   :  ?prefix:string *)
-  (*   -> url:string *)
-  (*   -> (key, value) storage_change_state *)
-  (*   -> unit Lwt.t *)
+  val on
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> (url:string -> (key, value) storage_change_state -> bool)
+    -> Js_of_ocaml.Dom.event_listener_id
 end

--- a/lib/js/interfaces.mli
+++ b/lib/js/interfaces.mli
@@ -156,7 +156,7 @@ type ('key, 'value) storage_change_state =
       }
   | Remove of
       { key : 'key
-      ; value : 'value
+      ; old_value : 'value
       }
   | Update of
       { key : 'key
@@ -249,11 +249,63 @@ module type STORAGE = sig
 
   (** {1 Event Handling} *)
 
+  (** [on ?capture ?once ?passive ?prefix] sets up a function that will be
+      called whenever the storage change. It return an [event_listener_id] (in
+      order to be revoked). A [prefix]. a prefix can be given to filter on keys
+      starting only with the prefix. *)
   val on
     :  ?capture:bool
     -> ?once:bool
     -> ?passive:bool
     -> ?prefix:string
-    -> (url:string -> (key, value) storage_change_state -> bool)
+    -> ((key, value) storage_change_state
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** A specialized version of {!val:on} only for storage clearing. *)
+  val on_clear
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> (Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** A specialized version of {!val:on} only for storage insertion. *)
+  val on_insert
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> (key:key
+        -> value:value
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** A specialized version of {!val:on} only for storage deletion (the value of
+      the handler contains the deleted value). *)
+  val on_remove
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> (key:key
+        -> old_value:value
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** A specialized version of {!val:on} only for storage update. *)
+  val on_update
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> (key:key
+        -> old_value:value
+        -> new_value:value
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
     -> Js_of_ocaml.Dom.event_listener_id
 end

--- a/lib/js/interfaces.mli
+++ b/lib/js/interfaces.mli
@@ -64,6 +64,9 @@ module type OPTIONAL = sig
 
   include FOLDABLE_OPTION (** @inline *)
 
+  (** [iter f x] performs [f] on the value wrapped into [x]. *)
+  val iter : ('a -> unit) -> 'a t -> unit
+
   (** Equality between optional values. *)
   val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 

--- a/lib/js/interfaces.mli
+++ b/lib/js/interfaces.mli
@@ -177,6 +177,11 @@ module type STORAGE_SERIALIZABLE = sig
   val read : string -> t option
 end
 
+(** The module that describe the prefix/scope of a key. *)
+module type PREFIXED_KEY = sig
+  val prefix : string
+end
+
 (** {2 Storage requirement} *)
 
 module type STORAGE_REQUIREMENT = sig

--- a/lib/js/interfaces.mli
+++ b/lib/js/interfaces.mli
@@ -252,7 +252,7 @@ module type STORAGE = sig
       [p key value]. *)
   val filter : (key -> value -> bool) -> slice
 
-  (** {1 Event Handling} *)
+  (** {1 Events Handling} *)
 
   (** [on ?capture ?once ?passive ?prefix] sets up a function that will be
       called whenever the storage change. It return an [event_listener_id] (in
@@ -313,4 +313,66 @@ module type STORAGE = sig
         -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
         -> unit)
     -> Js_of_ocaml.Dom.event_listener_id
+
+  (** [event_to_change ev] compute a [(key, value) storage_change_state] from a
+      storage event.*)
+  val event_to_change
+    :  Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+    -> (key, value) storage_change_state
+
+  (** [event_is_related ev] returns [true] if the event is related to the
+      backend, otherwise [false]. *)
+  val event_is_related
+    :  Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+    -> bool
+
+  (** {2 Lwt events}
+
+      Some event description to deal with [js_of_ocaml-lwt] (using
+      [Lwt_js_event]). *)
+
+  (** Lwt version of [on]. *)
+  val lwt_on
+    :  ?capture:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> unit
+    -> ((key, value) storage_change_state
+       * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t)
+       Lwt.t
+
+  (** Lwt version of [on_clear]. *)
+  val lwt_on_clear
+    :  ?capture:bool
+    -> ?passive:bool
+    -> unit
+    -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t Lwt.t
+
+  (** Lwt version of [on_insert]. *)
+  val lwt_on_insert
+    :  ?capture:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> unit
+    -> (key * value * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t) Lwt.t
+
+  (** Lwt version of [on_remove]. *)
+  val lwt_on_remove
+    :  ?capture:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> unit
+    -> (key * value * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t) Lwt.t
+
+  (** Lwt version of [on_update]. *)
+  val lwt_on_update
+    :  ?capture:bool
+    -> ?passive:bool
+    -> ?prefix:string
+    -> unit
+    -> (key
+       * value
+       * [ `Old_value of value ]
+       * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t)
+       Lwt.t
 end

--- a/lib/js/nightmare_js.ml
+++ b/lib/js/nightmare_js.ml
@@ -29,3 +29,4 @@ module Option = Optional.Option
 module Nullable = Optional.Nullable
 module Undefinable = Optional.Undefinable
 module Console = Console
+module Storage = Storage

--- a/lib/js/optional.ml
+++ b/lib/js/optional.ml
@@ -26,6 +26,7 @@ module Make (R : Interfaces.FOLDABLE_OPTION) = struct
   include R
 
   let halt () = empty
+  let iter f x = fold (fun () -> ()) f x
 
   let equal f left right =
     let left_is_empty () = fold (fun () -> true) (fun _ -> false) right

--- a/lib/js/storage.ml
+++ b/lib/js/storage.ml
@@ -1,0 +1,127 @@
+(*  MIT License
+
+    Copyright (c) 2023 funkywork
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE. *)
+
+exception Not_supported
+
+type ('key, 'value) change = ('key, 'value) Interfaces.storage_change_state =
+  | Clear
+  | Insert of
+      { key : 'key
+      ; value : 'value
+      }
+  | Remove of
+      { key : 'key
+      ; value : 'value
+      }
+  | Update of
+      { key : 'key
+      ; old_value : 'value
+      ; new_value : 'value
+      }
+
+module type VALUE = Interfaces.STORAGE_SERIALIZABLE
+module type REQUIREMENT = Interfaces.STORAGE_REQUIREMENT
+module type S = Interfaces.STORAGE
+
+module Make (Req : REQUIREMENT) = struct
+  open Js_of_ocaml
+  open Optional
+
+  type key = string
+  type value = string
+
+  module Map = Map.Make (String)
+
+  type slice = value Map.t
+
+  let storage =
+    Optional.Undefinable.fold
+      (fun () -> raise Not_supported)
+      (fun x -> x)
+      Req.handler
+  ;;
+
+  let unwrap_string s =
+    let open Option in
+    Js.to_string <$> (s |> from_opt)
+  ;;
+
+  let length () = storage##.length
+  let clear () = storage##clear
+  let remove key = storage##removeItem (Js.string key)
+  let get key = storage##getItem (Js.string key) |> unwrap_string
+  let key i = storage##key i |> unwrap_string
+
+  let set key value =
+    let k = Js.string key
+    and v = Js.string value in
+    storage##setItem k v
+  ;;
+
+  let update f key =
+    let previous_value = get key in
+    let final_value = f previous_value in
+    let () =
+      match final_value with
+      | None -> remove key
+      | Some new_value -> set key new_value
+    in
+    final_value
+  ;;
+
+  let nth i =
+    let open Option.Monad in
+    let* k = key i in
+    let+ v = get k in
+    k, v
+  ;;
+
+  let fold f default =
+    let len = length () in
+    let rec aux acc i =
+      if i < len
+      then (
+        match nth i with
+        | None -> raise Not_found (* Should not happen. *)
+        | Some (k, v) -> aux (f acc k v) (succ i))
+      else acc
+    in
+    aux default 0
+  ;;
+
+  let filter predicate =
+    fold
+      (fun map key value ->
+        if predicate key value then Map.add key value map else map)
+      Map.empty
+  ;;
+
+  let to_map () = filter (fun _ _ -> true)
+end
+
+module Local = Make (struct
+  let handler = Js_of_ocaml.Dom_html.window##.localStorage
+end)
+
+module Session = Make (struct
+  let handler = Js_of_ocaml.Dom_html.window##.sessionStorage
+end)

--- a/lib/js/storage.mli
+++ b/lib/js/storage.mli
@@ -41,9 +41,14 @@ type ('key, 'value) change = ('key, 'value) Interfaces.storage_change_state =
 
 (** {1 Storage Event} *)
 
+(** The type that describe a storage event (emit by [Local] or [Session]
+    storage)*)
 type event = Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
 
+(** The value of a storage event. Used for the function [addEventListener]. *)
 val event : event Js_of_ocaml.Dom.Event.typ
+
+(** Event handler for [Lwt_js_events]. *)
 
 (** {1 Common signatures} *)
 
@@ -86,16 +91,87 @@ module Ref
   (** The type that describe a Ref. *)
   type t
 
+  (** [make key] build a new reference indexed by [key]. *)
   val make : string -> t
+
+  (** [make_with key value] build a new reference indexed by the given [key] and
+      with the given value. *)
   val make_with : string -> Value.t -> t
+
+  (** [make_if_not_exists key value] build a new reference indexed by the given
+      [key] and if the value does not exists, it fill it with the given [value]. *)
   val make_if_not_exists : string -> Value.t -> t
+
+  (** [set reference value] set the [value] of the given [reference]. *)
   val set : t -> Value.t -> unit
+
+  (** [get reference] returns the value of the [given] reference. As the backend
+      is not controlled by the library, the result is wrapped into an option. *)
   val get : t -> Value.t option
 
+  (** {1 Events Handling} *)
+
+  (** [on ?capture ?once ?passive ?prefix] sets up a function that will be
+      called whenever the storage change. It return an [event_listener_id] (in
+      order to be revoked). A [prefix]. a prefix can be given to filter on keys
+      starting only with the prefix. *)
+  val on
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> key:string
+    -> ((t, Value.t) change
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** A specialized version of {!val:on} only for storage insertion. *)
+  val on_insert
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> key:string
+    -> (key:t
+        -> value:Value.t
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** A specialized version of {!val:on} only for storage deletion (the value of
+      the handler contains the deleted value). *)
+  val on_remove
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> key:string
+    -> (key:t
+        -> old_value:Value.t
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** A specialized version of {!val:on} only for storage update. *)
+  val on_update
+    :  ?capture:bool
+    -> ?once:bool
+    -> ?passive:bool
+    -> key:string
+    -> (key:t
+        -> old_value:Value.t
+        -> new_value:Value.t
+        -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+        -> unit)
+    -> Js_of_ocaml.Dom.event_listener_id
+
+  (** {1 Infix Operators} *)
+
   module Infix : sig
+    (** [!reference] is [get reference]. *)
     val ( ! ) : t -> Value.t option
+
+    (** [reference := value] is [set reference value]. *)
     val ( := ) : t -> Value.t -> unit
   end
 
-  include module type of Infix
+  include module type of Infix (** @inline*)
 end

--- a/lib/js/storage.mli
+++ b/lib/js/storage.mli
@@ -48,8 +48,6 @@ type event = Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
 (** The value of a storage event. Used for the function [addEventListener]. *)
 val event : event Js_of_ocaml.Dom.Event.typ
 
-(** Event handler for [Lwt_js_events]. *)
-
 (** {1 Common signatures} *)
 
 module type REQUIREMENT = Interfaces.STORAGE_REQUIREMENT

--- a/lib/js/storage.mli
+++ b/lib/js/storage.mli
@@ -107,6 +107,9 @@ module Ref
       is not controlled by the library, the result is wrapped into an option. *)
   val get : t -> Value.t option
 
+  (** [unset reference] remove the value positionned at the indexed reference. *)
+  val unset : t -> unit
+
   (** {1 Events Handling} *)
 
   (** [on ?capture ?once ?passive ?prefix] sets up a function that will be
@@ -160,6 +163,49 @@ module Ref
         -> Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
         -> unit)
     -> Js_of_ocaml.Dom.event_listener_id
+
+  (** {2 Lwt events}
+
+      Some event description to deal with [js_of_ocaml-lwt] (using
+      [Lwt_js_event]). *)
+
+  (** Lwt version of [on]. *)
+  val lwt_on
+    :  ?capture:bool
+    -> ?passive:bool
+    -> key:string
+    -> unit
+    -> ((t, Value.t) change
+       * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t)
+       Lwt.t
+
+  (** Lwt version of [on_insert]. *)
+  val lwt_on_insert
+    :  ?capture:bool
+    -> ?passive:bool
+    -> key:string
+    -> unit
+    -> (t * Value.t * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t) Lwt.t
+
+  (** Lwt version of [on_remove]. *)
+  val lwt_on_remove
+    :  ?capture:bool
+    -> ?passive:bool
+    -> key:string
+    -> unit
+    -> (t * Value.t * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t) Lwt.t
+
+  (** Lwt version of [on_update]. *)
+  val lwt_on_update
+    :  ?capture:bool
+    -> ?passive:bool
+    -> key:string
+    -> unit
+    -> (t
+       * Value.t
+       * [ `Old_value of Value.t ]
+       * Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t)
+       Lwt.t
 
   (** {1 Infix Operators} *)
 

--- a/lib/js/storage.mli
+++ b/lib/js/storage.mli
@@ -20,38 +20,45 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE. *)
 
-(** [Nightmare_js] provides an API for working with the web browser (via
-    [Js_of_ocaml]) and tries to provide bindings missing from the standard
-    [Js_of_ocaml] library. *)
+(** {1 Common types} *)
 
-(** {1 Types}
+(** Describes the change of state of a storage. Mostly used for event handling. *)
+type ('key, 'value) change = ('key, 'value) Interfaces.storage_change_state =
+  | Clear
+  | Insert of
+      { key : 'key
+      ; value : 'value
+      }
+  | Remove of
+      { key : 'key
+      ; value : 'value
+      }
+  | Update of
+      { key : 'key
+      ; old_value : 'value
+      ; new_value : 'value
+      }
 
-    Some common type aliases to simplify function signatures. *)
+(** {1 Common signatures} *)
 
-(**/**)
+module type VALUE = Interfaces.STORAGE_SERIALIZABLE
+module type REQUIREMENT = Interfaces.STORAGE_REQUIREMENT
+module type S = Interfaces.STORAGE
 
-module Aliases = Aliases
+(** {1 Exception}
 
-(**/**)
+    Exceptions are not supposed to appear, they are only present to make the API
+    complete. *)
 
-include module type of Aliases (** @inline *)
+(** In the age of our modern browsers, this exception should never be launched. *)
+exception Not_supported
 
-(** {2 Modules types} *)
+(** {1 Create a storage} *)
 
-module Bindings = Bindings
-module Interfaces = Interfaces
+module Make (Req : REQUIREMENT) :
+  S with type key = string and type value = string
 
-(** {2 Optional values} *)
+(** {1 Predefined storages} *)
 
-module Optional = Optional
-module Option = Optional.Option
-module Nullable = Optional.Nullable
-module Undefinable = Optional.Undefinable
-
-(** {2 Web Storage API} *)
-
-module Storage = Storage
-
-(** {1 Utils} *)
-
-module Console = Console
+module Local : S with type key = string and type value = string
+module Session : S with type key = string and type value = string

--- a/lib/js/storage.mli
+++ b/lib/js/storage.mli
@@ -31,7 +31,7 @@ type ('key, 'value) change = ('key, 'value) Interfaces.storage_change_state =
       }
   | Remove of
       { key : 'key
-      ; value : 'value
+      ; old_value : 'value
       }
   | Update of
       { key : 'key

--- a/lib/js/storage.mli
+++ b/lib/js/storage.mli
@@ -39,6 +39,12 @@ type ('key, 'value) change = ('key, 'value) Interfaces.storage_change_state =
       ; new_value : 'value
       }
 
+(** {1 Storage Event} *)
+
+type event = Js_of_ocaml.Dom_html.storageEvent Js_of_ocaml.Js.t
+
+val event : event Js_of_ocaml.Dom.Event.typ
+
 (** {1 Common signatures} *)
 
 module type VALUE = Interfaces.STORAGE_SERIALIZABLE


### PR DESCRIPTION
This is the first draft of the WebStorage API (`SessionStorage` and `LocalStorage`). 
The PR adds: 
- An OCaml interface on top of the WebStorage API
- A support for regular event handler (using `on_xxx` function)
- A support for `Lwt_js_event` (through `async_loop` and `buffered_loop`)
- The support of Persistent References (built on top of Local or Session Storage) with events and Lwt events.

A this moment, in order to try to keep the patch small, I delay the implementation of examples for a next PR.