### PR TITLE
Improve README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,26 @@
 
 > **Warning** _Nightmare_ is still _Work In Progress_.
 
-A set of components that fit, a priori, relatively well with the web framework
+A set of components that fit, in theory, relatively well with the web framework
 ([OCaml](https://ocaml.org)) [Dream](https://aantron.github.io/dream/) to try to
-build, at best, and quickly, dynamic web applications.
+build quickly and as best as possible dynamic web applications.
 
 **Nightmare** was very much inspired by the development of
 [Muhokama](https://github.com/xvw/muhokama/), a forum written in
-[OCaml](https://ocaml.org) which has had many of its components imported
+[OCaml](https://ocaml.org) which had many of its components imported
 directly into **Nightmare**. The set of ideas implemented in this "adhoc
 framework" comes from different sources of inspiration which we will try to list
 meticulously in an appropriate section.
 
 Even though the framework is intended to be as agnostic as possible, it has been
 designed to blend in naturally with [Dream](https://aantron.github.io/dream/),
-hence the name chosen.
+hence the library's name.
 
 ## Setting up the development environment
 
-Setting up a development environment is quite common. We recommend setting up a
-local switch to collect dependencies locally. Here are the commands to enter to
-initiate the environment:
+Setting up a development environment is quite straightforward. We recommend setting
+up a local switch to collect dependencies locally. Here are the commands to enter
+to initialize the environment:
 
 ```shellsession
 opam update


### PR DESCRIPTION
The only commit in this PR fixes some mishaps in the README's wording to make it a bit clearer and natural