### PR TITLE
Move Interfaces and Bindings outside of the API

### DIFF
--- a/lib/js/nightmare_js.ml
+++ b/lib/js/nightmare_js.ml
@@ -22,8 +22,6 @@
 
 module Aliases = Aliases
 include Aliases
-module Bindings = Bindings
-module Interfaces = Interfaces
 module Optional = Optional
 module Option = Optional.Option
 module Nullable = Optional.Nullable

--- a/lib/js/nightmare_js.mli
+++ b/lib/js/nightmare_js.mli
@@ -36,11 +36,6 @@ module Aliases = Aliases
 
 include module type of Aliases (** @inline *)
 
-(* (\** {2 Modules types} *\) *)
-
-(* module Bindings = Bindings *)
-(* module Interfaces = Interfaces *)
-
 (** {2 Optional values} *)
 
 module Optional = Optional

--- a/lib/js/nightmare_js.mli
+++ b/lib/js/nightmare_js.mli
@@ -36,10 +36,10 @@ module Aliases = Aliases
 
 include module type of Aliases (** @inline *)
 
-(** {2 Modules types} *)
+(* (\** {2 Modules types} *\) *)
 
-module Bindings = Bindings
-module Interfaces = Interfaces
+(* module Bindings = Bindings *)
+(* module Interfaces = Interfaces *)
 
 (** {2 Optional values} *)
 


### PR DESCRIPTION
Although it's likely that we'll discover a new form of convention later, at the moment we seem to be used to having a `Bindings` module that describes the low-level plumbing of a JS library.

Re-exporting it from the root of the module, especially in Nightmare_js, creates conflicts with potential `Bindings` modules present in a library dependent on `Nightmare_js`.